### PR TITLE
Remove unused enabled option, add none option

### DIFF
--- a/charts/td-redis-operator/values.yaml
+++ b/charts/td-redis-operator/values.yaml
@@ -9,7 +9,7 @@ replicaCount: 1
 
 registry: tongduncloud
 
-# all|cluster|standby|manager
+# all|cluster|standby|manager|none
 type: all
 
 image:
@@ -20,7 +20,6 @@ monitorimage: redis-exporter:1.0
 secret: 88c185e86f684251
 
 cluster:
-  enabled: false
   name: jerry
   #  production|demo|staging
   env: demo
@@ -29,7 +28,6 @@ cluster:
   proxyimage: predixy:1.0
 
 standby:
-  enabled: false
   name: tom
   #  production|demo|staging
   env: demo


### PR DESCRIPTION
In the default [values.yaml](https://github.com/tongdun/td-redis-operator/blob/main/charts/td-redis-operator/values.yaml), there is an option `enabled` for both `cluster` and `standby`. But there is any trace of the use of this variable in the templates of the Chart. I suggest to just delete the option.

Furthemore, I suggest to precise that you can chose to deploy just the operator, by adding a value `none` (or any string different than `all|cluster|standby|manager`) for the `type` option.